### PR TITLE
Unquote in tests

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,5 @@
 -arg "-w '-notation-overridden'" -Q ./named_api NamedAPI
+-arg "-output-directory ."
 
 # API
 named_api/API/core.v

--- a/named_api/UnitTests/t07_nested_types.v
+++ b/named_api/UnitTests/t07_nested_types.v
@@ -32,6 +32,21 @@ MetaRocq Run (tmMsg "01/15 RoseTree").
 Redirect "named_api/UnitTests/tests/07_01_RoseTree_coq" MetaRocq Run (print_rec "RoseTree").
 Redirect "named_api/UnitTests/tests/07_01_RoseTree_gen" MetaRocq Run (generate Ep RoseTree).
 
+Unset MetaRocq Strict Unquote Universe Mode.
+MetaRocq Run (generate_named Ep "RoseTree_elim" (sType fresh_universe) RoseTree).
+
+Fixpoint list_param1_size {A} (s : A -> nat) {l} (r : list_param1 A (fun _ => nat) l) : nat :=
+  match r with
+  | nil_param1 => 0
+  | cons_param1 a sa l sl => S (sa + list_param1_size s sl)
+  end.
+
+Fixpoint rose_tree_size {A} (s : A -> nat) (r : RoseTree A) : nat :=
+  RoseTree_elim A (fun _ => nat)
+    (fun _ => 1)
+    (fun l hpar => S (list_param1_size (rose_tree_size s) hpar)) r.
+
+
 Inductive PairTree A : Type :=
 | Pleaf (a : A) : PairTree A
 | Pnode (p : (PairTree A) * (PairTree A)) : PairTree A.

--- a/named_api/UnitTests/unit_tests.v
+++ b/named_api/UnitTests/unit_tests.v
@@ -161,13 +161,23 @@ Section TestFunctions.
   Context (debug_func_type debug_func_term : bool).
   Context (debug_cparam debug_fth_ty debug_fth_tm : bool).
   Context (Ep : param_env).
+  Context (name : option ident).
+  Context (output_univ : option Sort.t).
 
-Definition U := mk_output_univ (tSort sProp) (relev_sort (tSort sProp)).
+  Definition U := 
+    match output_univ with
+    | None => mk_output_univ (tSort sProp) (relev_sort (tSort sProp))
+    | Some u => mk_output_univ (tSort u) (relev_sort (tSort u))
+    end.
 
 Definition UnquoteAndPrint (x : term) : TemplateMonad unit :=
-  p <- (tmUnquote x) ;;
-  y <- (tmEval hnf p.(my_projT2)) ;;
-  tmPrint y.
+  match name with
+  | Some na => tmMkDefinition na x
+  | None =>
+    p <- (tmUnquote x) ;;
+    y <- (tmEval hnf p.(my_projT2)) ;;  
+    tmPrint y
+  end.
 
   #[using="All"]
   Definition generate_options {A} (s : A) : TemplateMonad unit :=
@@ -296,7 +306,10 @@ Definition generate {A} Ep : A -> _ := generate_options false false TestRecType
 
 Definition print_rec := print_rec_options false false false TestRecTerm.
 Definition generate {A} Ep : A -> _ := generate_options false false TestRecTerm
-                                        false false false false false false false Ep.
+                                        false false false false false false false Ep None None.
+
+Definition generate_named {A} Ep na u : A -> _ := generate_options false false TestRecTerm
+                                        false false false false false false false Ep (Some na) (Some u).
 
     (* ### Test Functoriality  ### *)
 


### PR DESCRIPTION
This allows to generate the derived eliminator directly by unquoting/mkDefinition.